### PR TITLE
add latest available tag for every major

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -11,7 +11,18 @@ Docker images for PostgreSQL with healtcheck, based on the official PostgreSQL a
 Images for `postresql-healtcheck` are based on official [postgres](https://hub.docker.com/_/postgres)
 images.
 
-* 9.5-alpine, 9.6-alpine, 10.1-alpine, 11.1-alpine, 11.4-alpine, 11.5-alpine, latest
+Current supported tags:
+
+ * 9.5-alpine
+ * 9.6-alpine
+ * 10.1-alpine
+ * 11.1-alpine
+ * 11.4-alpine
+ * 11.5-alpine
+ * 11.9-alpine
+ * 12.4-alpine
+ * 13.0-alpine
+ * latest
 
 ## Reference
 

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -7,4 +7,7 @@ export VARS='
   BASE_TAG=11.1-alpine
   BASE_TAG=11.4-alpine
   BASE_TAG=11.5-alpine
+  BASE_TAG=11.9-alpine
+  BASE_TAG=12.4-alpine
+  BASE_TAG=13.0-alpine
 '


### PR DESCRIPTION
Add a health check image for the recently released Postgres 13 🎉  https://www.postgresql.org/about/news/2077/ and update the latest references of 11 and 12 series.

I'm thinking of automating the tag extraction from Postgres' docker hub to keep this automatically synced but, for now, this would suffice.
