### PR TITLE
[PLN-8] Add support for Postgres 14.5

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -29,6 +29,7 @@ Current supported tags:
  * 13.2-alpine
  * 13.6-alpine
  * 14.3-alpine
+ * 14.5-alpine
 
 ## Reference
 

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -17,4 +17,5 @@ export VARS='
   BASE_TAG=13.2-alpine
   BASE_TAG=13.6-alpine
   BASE_TAG=14.3-alpine
+  BASE_TAG=14.5-alpine
 '


### PR DESCRIPTION
### References
[help]: # (Add link/s to every reference related to this pull request: issue, migrations, another PRs, ...)

* **Issue:** [PLN-8](https://jobandtalent.atlassian.net/browse/PLN-8)
* **Migrations:** N/A
* **Related pull-requests:** N/A
* **Rollbar errors:** N/A

### What is the goal? How is it being implemented?
[help]: # (Provide a description of the overall goal and a description of the implementation.)
Add support for Postgres 14.5 so `jobandtalent/postgres:14.5-alpine` image can be used in other services. It has been implemented accordingly to previous similar PR #9


