### PR TITLE
GI-90 Add support for Postgres 14.6

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -30,6 +30,7 @@ Current supported tags:
  * 13.6-alpine
  * 14.3-alpine
  * 14.5-alpine
+ * 14.6-alpine
 
 ## Reference
 

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -18,4 +18,5 @@ export VARS='
   BASE_TAG=13.6-alpine
   BASE_TAG=14.3-alpine
   BASE_TAG=14.5-alpine
+  BASE_TAG=14.6-alpine
 '


### PR DESCRIPTION
### References
[help]: # (Add link/s to every reference related to this pull request: issue, migrations, another PRs, ...)

* **Issue:** [GI-90](https://jobandtalent.atlassian.net/browse/GI-90)
* **Migrations:** N/A
* **Related pull-requests:** N/A
* **Rollbar errors:** N/A

### What is the goal? How is it being implemented?
[help]: # (Provide a description of the overall goal and a description of the implementation.)
Add support for Postgres 14.6 so `jobandtalent/postgres:14.6-alpine` image can be used in other services. It has been implemented accordingly to previous similar PR #12


