### PR TITLE
[FIX] Add support for Postgres 11.16

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -22,6 +22,7 @@ Current supported tags:
  * 11.9-alpine
  * 11.10-alpine
  * 11.11-alpine
+ * 11.16-alpine
  * 12.4-alpine
  * 12.5-alpine
  * 13.0-alpine

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -10,6 +10,7 @@ export VARS='
   BASE_TAG=11.9-alpine
   BASE_TAG=11.10-alpine
   BASE_TAG=11.11-alpine
+  BASE_TAG=11.16-alpine
   BASE_TAG=12.4-alpine
   BASE_TAG=12.5-alpine
   BASE_TAG=13.0-alpine


### PR DESCRIPTION
### References
[help]: # (Add link/s to every reference related to this pull request: issue, migrations, another PRs, ...)

* **Issue:** N/A
* **Migrations:** N/A
* **Related pull-requests:** N/A
* **Rollbar errors:** N/A

### What is the goal? How is it being implemented?
[help]: # (Provide a description of the overall goal and a description of the implementation.)
Add support for Postgres 11.16 so `jobandtalent/postgres:11.16-alpine` image can be used in other services.

It's going to be used in workforce both staging and production:
```ruby
workforce (Staging):001:0> ApplicationRecord.connection.execute("SELECT version();").to_a
{"log_level":"DEBUG","timestamp":"2023-02-28 12:22:38 +0000","message":"   (0.7ms)  SELECT version();","application":"workforce","source_code_commit_id":"b7e3f524e034a8fd35ba2111b2c40e12b097a86f","source_code_location":null,"jt_codeowner":"unknown"}
[
    [0] {
        "version" => "PostgreSQL 11.16 on aarch64-unknown-linux-gnu, compiled by aarch64-unknown-linux-gnu-gcc (GCC) 7.4.0, 64-bit"
    }
]
```
```ruby
workforce (Production!):003:0> ApplicationRecord.connection.execute("SELECT version();").to_a
[
    [0] {
        "version" => "PostgreSQL 11.16 on aarch64-unknown-linux-gnu, compiled by aarch64-unknown-linux-gnu-gcc (GCC) 7.4.0, 64-bit"
    }
]
```