### PR TITLE
Add support for Postgres 13.10

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -29,6 +29,7 @@ Current supported tags:
  * 13.1-alpine
  * 13.2-alpine
  * 13.6-alpine
+ * 13.10-alpine
  * 14.3-alpine
  * 14.5-alpine
  * 14.6-alpine

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -17,6 +17,7 @@ export VARS='
   BASE_TAG=13.1-alpine
   BASE_TAG=13.2-alpine
   BASE_TAG=13.6-alpine
+  BASE_TAG=13.10-alpine
   BASE_TAG=14.3-alpine
   BASE_TAG=14.5-alpine
   BASE_TAG=14.6-alpine


### PR DESCRIPTION
Adding support for Postgres 13.10 version, as it will be needed due to https://www.notion.so/jtproduct/Mandatory-minor-engine-upgrades-2023-a0425e0f73a94a39ab587a90a21ba6e2