### PR TITLE
Add 14.8 Postgres image

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -33,6 +33,7 @@ Current supported tags:
  * 14.3-alpine
  * 14.5-alpine
  * 14.6-alpine
+ * 14.8-alpine
 
 ## Reference
 

--- a/postgres/hooks/vars.sh
+++ b/postgres/hooks/vars.sh
@@ -21,4 +21,5 @@ export VARS='
   BASE_TAG=14.3-alpine
   BASE_TAG=14.5-alpine
   BASE_TAG=14.6-alpine
+  BASE_TAG=14.8-alpine
 '


### PR DESCRIPTION
Adding 14.8 Postgres image due to https://www.notion.so/jtproduct/Major-version-upgrades-2023-2d9efb34831742e1ab338be68e67d404