### PR TITLE
Optimize pg_repack Dockerfile to reduce the size

### DIFF
--- a/pgrepack/Dockerfile
+++ b/pgrepack/Dockerfile
@@ -1,19 +1,17 @@
-FROM ubuntu:20.04
-LABEL "Mantainer"="Jobandtalent Platform team <platform@jobandtalent.com>"
+FROM ubuntu:22.04
+
+LABEL "Maintainer"="Jobandtalent Platform team <platform@jobandtalent.com>"
 
 ARG PGREPACK_VERSION=${PGREPACK_VERSION}
+ARG BUILDDEPS="build-essential postgresql-server-dev-all libghc-readline-dev libzstd-dev liblz4-dev liblz-dev libssl-dev libcrypto++-dev zlib1g-dev pgxnclient"
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential \
-    pgxnclient \
-    libpq-dev \
-    postgresql-server-dev-all \
-    libghc-readline-dev \
-    libzstd-dev \
-    liblz4-dev \
-    liblz-dev \
-    libssl-dev \
-    libcrypto++-dev \
-    zlib1g-dev
-
-RUN pgxn install "pg_repack==${PGREPACK_VERSION}"
-RUN ln -s /usr/lib/postgresql/*/bin/pg_repack /usr/local/bin/pg_repack
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y $BUILDDEPS --no-install-recommends && \
+    pgxn install "pg_repack==${PGREPACK_VERSION}" && \
+    ln -s /usr/lib/postgresql/*/bin/pg_repack /usr/local/bin/pg_repack && \
+    apt-get remove --purge -y $BUILDDEPS && \
+    apt-get install -y libpq-dev --no-install-recommends && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc /usr/share/doc-base


### PR DESCRIPTION
The current image is too heavy and about 2 GB. With these changes, we are reducing it form 2 GB to 87 MB. Also, we're upgrading to a newer Ubuntu release. 

Unfortunately we can move it all the way to 24.04, since pg_repack 1.4.7 won't work there. Differences between the previous and new docker images after these changes: 

```REPOSITORY            TAG       IMAGE ID       CREATED          SIZE
pgrepack-ubuntu-new   latest    e61f6fe090e3   17 seconds ago   86.9MB
pgrepack-ubuntu-old   latest    7e7f7df13d1a   2 minutes ago    2.15GB
```