### PR TITLE
Add new riot version and refactor the Dockerfile

### DIFF
--- a/redis-riot/Dockerfile
+++ b/redis-riot/Dockerfile
@@ -1,12 +1,19 @@
-FROM ubuntu:20.04
+FROM alpine:3.20
 LABEL "Mantainer"="Jobandtalent Platform team <platform@jobandtalent.com>"
-ARG DEBIAN_FRONTEND=noninteractive
+
 ARG RIOT_VERSION=${RIOT_VERSION}
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y default-jre netcat wget unzip
-RUN wget https://github.com/redis-developer/riot/releases/download/v$RIOT_VERSION/riot-redis-$RIOT_VERSION.zip \
-    && unzip riot-redis-$RIOT_VERSION.zip \
-    && mv riot-redis-$RIOT_VERSION riot \
-    && rm riot-redis-$RIOT_VERSION.zip
+RUN apk update && apk upgrade && \
+    apk add --no-cache openjdk17-jre-headless netcat-openbsd wget unzip && \
+    # Remove unnecessary files to reduce the image size
+    rm -rf /var/cache/apk/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc /usr/share/licenses
+
+# Old and new versions use different file names.
+RUN (wget https://github.com/redis-developer/riot/releases/download/v$RIOT_VERSION/riot-$RIOT_VERSION.zip \
+    || wget https://github.com/redis-developer/riot/releases/download/v$RIOT_VERSION/riot-redis-$RIOT_VERSION.zip) \
+    && (unzip riot-$RIOT_VERSION.zip || unzip riot-redis-$RIOT_VERSION.zip) \
+    && (mv riot-$RIOT_VERSION riot && mv riot/bin/riot riot/bin/riot-redis || mv riot-redis-$RIOT_VERSION riot) \
+    && (rm riot-$RIOT_VERSION.zip || rm riot-redis-$RIOT_VERSION.zip) \
+    && apk del unzip wget
 
 WORKDIR riot/bin

--- a/redis-riot/hooks/vars.sh
+++ b/redis-riot/hooks/vars.sh
@@ -2,4 +2,5 @@
 
 export VARS='
   RIOT_VERSION=2.16.0
+  RIOT_VERSION=4.1.2
 '


### PR DESCRIPTION
Been a while since we used riot-redis to migrate Redis clusters, so I'd like to add the latest version. In addition:

* Moved the image to Alpine to make it lighter.
* Made it compatible with different files/versions. 